### PR TITLE
fix timestamp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+linters:
+  enable:
+    - deadcode
+    - errcheck
+    - goconst
+    - gofmt
+    - golint
+    - gosec
+    - govet
+    - ineffassign
+    - interfacer
+    - megacheck
+    - misspell
+    - nakedret
+    - structcheck
+    - unconvert
+    - varcheck
+  enable-all: false
+run:
+  skip-files:
+    - schema.go
+    - pulumiManifest.go
+  timeout: 20m

--- a/cmd/aws-sso-creds/get/cli.go
+++ b/cmd/aws-sso-creds/get/cli.go
@@ -45,7 +45,7 @@ func Command() *cobra.Command {
 
 			fmt.Println("")
 
-			fmt.Println("These credentials will expire at:", Red((time.Unix(*creds.RoleCredentials.Expiration, 0).Format(time.UnixDate))))
+			fmt.Println("These credentials will expire at:", Red(time.UnixMilli(*creds.RoleCredentials.Expiration).UTC()))
 
 			return nil
 		},


### PR DESCRIPTION
Timestamps from the AWS SSO API is returned in milliseconds now, so fixing the return date

Fixes #9