### PR TITLE
adds support for the "default" profile instead of failing

### DIFF
--- a/cmd/aws-sso-creds/export/cli.go
+++ b/cmd/aws-sso-creds/export/cli.go
@@ -21,10 +21,6 @@ func Command() *cobra.Command {
 			profile := viper.GetString("profile")
 			homeDir := viper.GetString("home-directory")
 
-			if profile == "" {
-				return fmt.Errorf("no profile specified")
-			}
-
 			creds, _, err := credentials.GetSSOCredentials(profile, homeDir)
 
 			if err != nil {

--- a/cmd/aws-sso-creds/get/cli.go
+++ b/cmd/aws-sso-creds/get/cli.go
@@ -25,10 +25,6 @@ func Command() *cobra.Command {
 			profile := viper.GetString("profile")
 			homeDir := viper.GetString("home-directory")
 
-			if profile == "" {
-				return fmt.Errorf("no profile specified")
-			}
-
 			creds, accountID, err := credentials.GetSSOCredentials(profile, homeDir)
 
 			if err != nil {

--- a/cmd/aws-sso-creds/helper/cli.go
+++ b/cmd/aws-sso-creds/helper/cli.go
@@ -30,10 +30,6 @@ func Command() *cobra.Command {
 			profile := viper.GetString("profile")
 			homeDir := viper.GetString("home-directory")
 
-			if profile == "" {
-				return fmt.Errorf("no profile specified")
-			}
-
 			creds, _, err := credentials.GetSSOCredentials(profile, homeDir)
 
 			if err != nil {

--- a/cmd/aws-sso-creds/list/accounts/cli.go
+++ b/cmd/aws-sso-creds/list/accounts/cli.go
@@ -38,10 +38,6 @@ func Command() *cobra.Command {
 			profile := viper.GetString("profile")
 			homeDir := viper.GetString("home-directory")
 
-			if profile == "" {
-				return fmt.Errorf("no profile specified")
-			}
-
 			ssoConfig, err := config.GetSSOConfig(profile, homeDir)
 			if err != nil {
 				return fmt.Errorf("error retrieving SSO config: %w", err)

--- a/cmd/aws-sso-creds/list/roles/cli.go
+++ b/cmd/aws-sso-creds/list/roles/cli.go
@@ -40,10 +40,6 @@ func Command() *cobra.Command {
 			profile := viper.GetString("profile")
 			homeDir := viper.GetString("home-directory")
 
-			if profile == "" {
-				return fmt.Errorf("no profile specified")
-			}
-
 			ssoConfig, err := config.GetSSOConfig(profile, homeDir)
 			if err != nil {
 				return fmt.Errorf("error retrieving SSO config: %w", err)

--- a/cmd/aws-sso-creds/set/cli.go
+++ b/cmd/aws-sso-creds/set/cli.go
@@ -35,10 +35,6 @@ func Command() *cobra.Command {
 			fmt.Println(credsPath)
 			fmt.Println(cfgPath)
 
-			if profile == "" {
-				return fmt.Errorf("no profile specified")
-			}
-
 			creds, _, err := credentials.GetSSOCredentials(profile, homeDir)
 			if err != nil {
 				return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,13 @@ func GetSSOConfig(profile string, homedir string) (*SSOConfig, error) {
 	}
 
 	// build a section name
-	section := fmt.Sprintf("profile %s", profile)
+	var section string
+	if (profile == "") {
+		section = "default"
+		profile = "<default>"
+	} else {
+		section = fmt.Sprintf("profile %s", profile)
+	}
 
 	// FIXME: make this better
 	if p.HasSection(section) {
@@ -48,6 +54,6 @@ func GetSSOConfig(profile string, homedir string) (*SSOConfig, error) {
 
 	}
 
-	return nil, fmt.Errorf("unable to find profile %s", profile)
+	return nil, fmt.Errorf("unable to find profile: %s", profile)
 
 }


### PR DESCRIPTION
adds support for the "default" profile instead of failing when a profile isn't specified:

```ini
[default]
sso_start_url = https://org-sso.awsapps.com/start
sso_region = us-east-1
sso_account_id = 123456789
sso_role_name = ReadOnly
region = us-east-1
output = json
```
