### PR TITLE
default config with no 'profile' prefix

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,7 @@ func GetSSOConfig(profile string, homedir string) (*SSOConfig, error) {
 
 	// build a section name
 	var section string
-	if profile == "" {
+	if profile == "" || profile == "default" {
 		section = "default"
 		profile = "<default>"
 	} else {


### PR DESCRIPTION
For some reason, the profile is getting set as default, and the section gets set as "profile default" which causes the config not to be found