### PR TITLE
feat: add exec sub-command to run commands with AWS SSO credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ Use it with `Invoke-Expression` :-
 > aws-sso-creds export-ps | Invoke-Expression
 ```
 
+## Execute a command with credentials
+
+If you want to run a command with AWS credentials injected into its environment without modifying your current shell, use `aws-sso-creds exec`:
+
+```bash
+aws-sso-creds -p my-profile exec -- aws s3 ls
+```
+
+Or using the `AWS_PROFILE` environment variable:
+
+```bash
+AWS_PROFILE=my-profile aws-sso-creds exec -- aws s3 ls
+```
+
+This runs the given command with `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` set in its environment.
+
 ## List accounts
 
 You can also list the accounts you have available within AWS SSO:

--- a/cmd/aws-sso-creds/exec/cli.go
+++ b/cmd/aws-sso-creds/exec/cli.go
@@ -1,0 +1,49 @@
+package exec
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/jaxxstorm/aws-sso-creds/pkg/credentials"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func Command() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "exec -- <command> [args...]",
+		Short: "Execute a command with AWS temporary credentials in the environment",
+		Long:  "Execute a command with AWS temporary credentials injected as environment variables",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			cmd.SilenceUsage = true
+
+			profile := viper.GetString("profile")
+			homeDir := viper.GetString("home-directory")
+
+			creds, _, err := credentials.GetSSOCredentials(profile, homeDir)
+			if err != nil {
+				return err
+			}
+
+			binary, err := exec.LookPath(args[0])
+			if err != nil {
+				return fmt.Errorf("command not found: %s", args[0])
+			}
+
+			env := os.Environ()
+			env = append(env,
+				fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", *creds.RoleCredentials.AccessKeyId),
+				fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", *creds.RoleCredentials.SecretAccessKey),
+				fmt.Sprintf("AWS_SESSION_TOKEN=%s", *creds.RoleCredentials.SessionToken),
+			)
+
+			return syscall.Exec(binary, args, env)
+		},
+	}
+
+	return command
+}

--- a/cmd/aws-sso-creds/main.go
+++ b/cmd/aws-sso-creds/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/jaxxstorm/aws-sso-creds/cmd/aws-sso-creds/exec"
 	"github.com/jaxxstorm/aws-sso-creds/cmd/aws-sso-creds/export"
 	"github.com/jaxxstorm/aws-sso-creds/cmd/aws-sso-creds/exportps"
 	"github.com/jaxxstorm/aws-sso-creds/cmd/aws-sso-creds/get"
@@ -29,6 +30,7 @@ func configureCLI() *cobra.Command {
 	rootCommand.AddCommand(get.Command())
 	rootCommand.AddCommand(set.Command())
 	rootCommand.AddCommand(version.Command())
+	rootCommand.AddCommand(exec.Command())
 	rootCommand.AddCommand(export.Command())
 	rootCommand.AddCommand(exportps.Command())
 	rootCommand.AddCommand(list.Command())


### PR DESCRIPTION
Adds an `exec` sub-command that runs a given command with AWS temporary credentials injected as environment variables, without modifying the current shell.

## Usage

```bash
aws-sso-creds -p my-profile exec -- aws s3 ls
# or
AWS_PROFILE=my-profile aws-sso-creds exec -- aws s3 ls
```

## Details

- Uses `syscall.Exec` to replace the process with the target command, inheriting the current environment plus `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` .
- This is useful when you want to run a one-off command with SSO credentials without exporting variables into your shell session.

## Note
The `exec` sub-command does not set `AWS_PROFILE` in the child process - since the temporary credentials are already injected, the child doesn't need to know which profile they came from. If `AWS_PROFILE` is already in the environment, it is left as-is.

It would also be useful to set `AWS_DEFAULT_REGION` to the region from the specified profile, which may differ from the SSO endpoint's region. This is particularly helpful if your `~/.aws/config` has a default profile with a non-standard region (e.g., localhost) - a common setup when working with multiple accounts to prevent accidentally running operations against the wrong one.

This would require a small refactoring in `GetSSOCredentials`. If you're interested, I can open a separate PR for that.
