### PR TITLE
Scope SSO region to the SSO client

### DIFF
--- a/cmd/aws-sso-creds/exec/cli.go
+++ b/cmd/aws-sso-creds/exec/cli.go
@@ -24,7 +24,7 @@ func Command() *cobra.Command {
 			profile := viper.GetString("profile")
 			homeDir := viper.GetString("home-directory")
 
-			creds, _, err := credentials.GetSSOCredentials(profile, homeDir)
+			creds, _, cfg, err := credentials.GetSSOCredentials(profile, homeDir)
 			if err != nil {
 				return err
 			}
@@ -39,6 +39,7 @@ func Command() *cobra.Command {
 				fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", *creds.RoleCredentials.AccessKeyId),
 				fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", *creds.RoleCredentials.SecretAccessKey),
 				fmt.Sprintf("AWS_SESSION_TOKEN=%s", *creds.RoleCredentials.SessionToken),
+				fmt.Sprintf("AWS_DEFAULT_REGION=%s", cfg.Region),
 			)
 
 			return syscall.Exec(binary, args, env)

--- a/cmd/aws-sso-creds/export/cli.go
+++ b/cmd/aws-sso-creds/export/cli.go
@@ -21,7 +21,7 @@ func Command() *cobra.Command {
 			profile := viper.GetString("profile")
 			homeDir := viper.GetString("home-directory")
 
-			creds, _, err := credentials.GetSSOCredentials(profile, homeDir)
+			creds, _, _, err := credentials.GetSSOCredentials(profile, homeDir)
 
 			if err != nil {
 				return err

--- a/cmd/aws-sso-creds/exportps/cli.go
+++ b/cmd/aws-sso-creds/exportps/cli.go
@@ -21,7 +21,7 @@ func Command() *cobra.Command {
 			profile := viper.GetString("profile")
 			homeDir := viper.GetString("home-directory")
 
-			creds, _, err := credentials.GetSSOCredentials(profile, homeDir)
+			creds, _, _, err := credentials.GetSSOCredentials(profile, homeDir)
 
 			if err != nil {
 				return err

--- a/cmd/aws-sso-creds/get/cli.go
+++ b/cmd/aws-sso-creds/get/cli.go
@@ -34,7 +34,7 @@ func Command() *cobra.Command {
 			homeDir := viper.GetString("home-directory")
 			exportJSON, _ := cmd.Flags().GetBool("json")
 
-			creds, accountID, err := credentials.GetSSOCredentials(profile, homeDir)
+			creds, ssoConfig, _, err := credentials.GetSSOCredentials(profile, homeDir)
 
 			if err != nil {
 				return err
@@ -54,7 +54,7 @@ func Command() *cobra.Command {
 				fmt.Println(string(output))
 			} else {
 
-				fmt.Println(aurora.Sprintf("Your temporary credentials for account %s are:", aurora.White(accountID)))
+				fmt.Println(aurora.Sprintf("Your temporary credentials for account %s are:", aurora.White(ssoConfig.AccountID)))
 				fmt.Println("")
 
 				fmt.Fprintln(os.Stdout, "AWS_ACCESS_KEY_ID\t", *creds.RoleCredentials.AccessKeyId)

--- a/cmd/aws-sso-creds/helper/cli.go
+++ b/cmd/aws-sso-creds/helper/cli.go
@@ -3,10 +3,11 @@ package helper
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/jaxxstorm/aws-sso-creds/pkg/credentials"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"time"
 )
 
 type CredentialsProcessOutput struct {
@@ -30,7 +31,7 @@ func Command() *cobra.Command {
 			profile := viper.GetString("profile")
 			homeDir := viper.GetString("home-directory")
 
-			creds, _, err := credentials.GetSSOCredentials(profile, homeDir)
+			creds, _, _, err := credentials.GetSSOCredentials(profile, homeDir)
 
 			if err != nil {
 				return err

--- a/cmd/aws-sso-creds/set/cli.go
+++ b/cmd/aws-sso-creds/set/cli.go
@@ -35,7 +35,7 @@ func Command() *cobra.Command {
 			fmt.Println(credsPath)
 			fmt.Println(cfgPath)
 
-			creds, _, err := credentials.GetSSOCredentials(profile, homeDir)
+			creds, _, _, err := credentials.GetSSOCredentials(profile, homeDir)
 			if err != nil {
 				return err
 			}

--- a/pkg/credentials/creds.go
+++ b/pkg/credentials/creds.go
@@ -12,31 +12,34 @@ import (
 	cfg "github.com/jaxxstorm/aws-sso-creds/pkg/config"
 )
 
-func GetSSOCredentials(profile string, homedir string) (*sso.GetRoleCredentialsOutput, string, error) {
+func GetSSOCredentials(profile string, homedir string) (*sso.GetRoleCredentialsOutput, *cfg.SSOConfig, *aws.Config, error) {
 	ssoConfig, err := cfg.GetSSOConfig(profile, homedir)
 	if err != nil {
-		return nil, "", fmt.Errorf("error retrieving SSO config: %w", err)
+		return nil, nil, nil, fmt.Errorf("error retrieving SSO config: %w", err)
 	}
 
 	cacheFiles, err := os.ReadDir(filepath.Join(homedir, ".aws", "sso", "cache"))
 	if err != nil {
-		return nil, "", fmt.Errorf("error retrieving cache files - perhaps you need to login?: %w", err)
+		return nil, ssoConfig, nil, fmt.Errorf("error retrieving cache files - perhaps you need to login?: %w", err)
 	}
 
 	token, err := cfg.GetSSOToken(cacheFiles, *ssoConfig, homedir)
 	if err != nil {
-		return nil, "", fmt.Errorf("error retrieving SSO token from cache files: %w", err)
+		return nil, ssoConfig, nil, fmt.Errorf("error retrieving SSO token from cache files: %w", err)
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.TODO(),
-		config.WithRegion(ssoConfig.Region),
+		// Don't set the region here in config because it would affect all clients created from this config
 		config.WithSharedConfigProfile(profile),
 	)
 	if err != nil {
-		return nil, "", fmt.Errorf("error loading AWS configuration: %w", err)
+		return nil, ssoConfig, nil, fmt.Errorf("error loading AWS configuration: %w", err)
 	}
 
-	svc := sso.NewFromConfig(cfg)
+	svc := sso.NewFromConfig(cfg, func(o *sso.Options) {
+		// We specify the SSO region here because it applies only to this client instance
+		o.Region = ssoConfig.Region
+	})
 
 	creds, err := svc.GetRoleCredentials(context.TODO(), &sso.GetRoleCredentialsInput{
 		AccessToken: aws.String(token),
@@ -44,8 +47,8 @@ func GetSSOCredentials(profile string, homedir string) (*sso.GetRoleCredentialsO
 		RoleName:    aws.String(ssoConfig.RoleName),
 	})
 	if err != nil {
-		return nil, "", fmt.Errorf("error retrieving credentials from AWS: %w", err)
+		return nil, ssoConfig, &cfg, fmt.Errorf("error retrieving credentials from AWS: %w", err)
 	}
 
-	return creds, ssoConfig.AccountID, nil
+	return creds, ssoConfig, &cfg, nil
 }


### PR DESCRIPTION
The SSO region was being applied to the shared AWS config, which caused all AWS clients derived from that config to use the SSO region instead of the profile's configured region. This change scopes the SSO region to only the SSO client.

Also return the SSOConfig and aws.Config from GetSSOCredentials so callers can access profile metadata (e.g. AccountID, Region) directly. The `exec` command now sets `AWS_DEFAULT_REGION` from the profile config.

This means users with profiles targeting different regions (e.g. us-east-2, sa-east-1) will now have the correct region forwarded to commands run via `exec`.